### PR TITLE
Removed [] from github example

### DIFF
--- a/docs/link/REPOSITORY.md
+++ b/docs/link/REPOSITORY.md
@@ -65,7 +65,7 @@ In addition, if you want your links to point to a specific branch of the reposit
     "github": {
             "repository": "example/react-components",
             "branch": "develop"
-     }
+    }
 }
 ```
 

--- a/docs/link/REPOSITORY.md
+++ b/docs/link/REPOSITORY.md
@@ -62,12 +62,10 @@ In addition, if you want your links to point to a specific branch of the reposit
     "components": [
         …
     ],
-    "github": [
-        {
+    "github": {
             "repository": "example/react-components",
             "branch": "develop"
-        }
-    ]
+     }
 }
 ```
 


### PR DESCRIPTION
Removed array brackets as the zeplin connect schema expects an object, not an array
